### PR TITLE
Upgrade Kanister blueprint version to v0.118.0

### DIFF
--- a/aws-rds-postgres/README.md
+++ b/aws-rds-postgres/README.md
@@ -9,7 +9,7 @@ This example is to demonstrate how Kanister can be integrated with AWS RDS insta
 ## Prerequisites
 
 - Kubernetes 1.10+
-- Kanister controller version 0.116.0 installed in your cluster
+- Kanister controller version 0.118.0 installed in your cluster
 - Kanctl CLI installed (https://docs.kanister.io/tooling.html#kanctl)
 
 ## Create RDS instance on AWS

--- a/aws-rds-postgres/aws-rds-postgres-blueprint.yaml
+++ b/aws-rds-postgres/aws-rds-postgres-blueprint.yaml
@@ -14,7 +14,7 @@ actions:
     - func: KubeTask
       name: backupSnapshots
       args:
-        image: "ghcr.io/kanisterio/postgres-kanister-tools:0.116.0"
+        image: "ghcr.io/kanisterio/postgres-kanister-tools:0.118.0"
         namespace: "{{ .Object.metadata.namespace }}"
         command:
           - bash
@@ -53,7 +53,7 @@ actions:
     - func: KubeTask
       name: restoreSnapshots
       args:
-        image: "ghcr.io/kanisterio/postgres-kanister-tools:0.116.0"
+        image: "ghcr.io/kanisterio/postgres-kanister-tools:0.118.0"
         namespace: "{{ .Object.metadata.namespace }}"
         command:
           - bash
@@ -90,7 +90,7 @@ actions:
     - func: KubeTask
       name: restoreSnapshots
       args:
-        image: "ghcr.io/kanisterio/postgres-kanister-tools:0.116.0"
+        image: "ghcr.io/kanisterio/postgres-kanister-tools:0.118.0"
         namespace: "{{ .Namespace.Name }}"
         command:
           - bash

--- a/aws-rds-postgres/aws-rds-postgres-dump-blueprint.yaml
+++ b/aws-rds-postgres/aws-rds-postgres-dump-blueprint.yaml
@@ -96,7 +96,7 @@ actions:
       name: deleteBackup
       args:
         namespace: "{{ .Namespace.Name }}"
-        image: ghcr.io/kanisterio/kanister-tools:0.116.0
+        image: ghcr.io/kanisterio/kanister-tools:0.118.0
         command:
           - bash
           - -o

--- a/cassandra/README.md
+++ b/cassandra/README.md
@@ -7,7 +7,7 @@ As the official documentation of [Cassandra](http://cassandra.apache.org/) says,
 * Kubernetes 1.9+
 * Kubernetes beta APIs enabled only if `podDisruptionBudget` is enabled
 * PV support on the underlying infrastructure
-* Kanister controller version 0.116.0 installed in your cluster, let's say in namespace `<kanister-operator-namespace>`
+* Kanister controller version 0.118.0 installed in your cluster, let's say in namespace `<kanister-operator-namespace>`
 * Kanctl CLI installed (https://docs.kanister.io/tooling.html#kanctl)
 
 To install kanister and related tools you can follow [this](https://docs.kanister.io/install.html#install) link.
@@ -29,7 +29,7 @@ $ helm repo add bitnami https://charts.bitnami.com/bitnami
 $ helm repo update
 # remove app-namespace with the namespace you want to deploy the Cassandra app in
 $ kubectl create ns <app-namespace>
-$ helm install cassandra bitnami/cassandra --namespace <app-namespace> --set image.repository=kanisterio/cassandra --set image.tag=0.116.0 --set cluster.replicaCount=2 --set image.registry=ghcr.io --set image.pullPolicy=Always
+$ helm install cassandra bitnami/cassandra --namespace <app-namespace> --set image.repository=kanisterio/cassandra --set image.tag=0.118.0 --set cluster.replicaCount=2 --set image.registry=ghcr.io --set image.pullPolicy=Always
 
 
 ```

--- a/cassandra/cassandra-blueprint.yaml
+++ b/cassandra/cassandra-blueprint.yaml
@@ -130,7 +130,7 @@ actions:
       name: restoreFromObjectStore
       args:
         namespace: "{{ .StatefulSet.Namespace }}"
-        image: ghcr.io/kanisterio/kanister-tools:0.116.0
+        image: ghcr.io/kanisterio/kanister-tools:0.118.0
         backupArtifactPrefix: "{{ .ArtifactsIn.params.KeyValue.backupPrefixLocation }}"
         pods: "{{ range .StatefulSet.Pods }} {{.}}{{end}}"
         restorePath: "{{ .ArtifactsIn.params.KeyValue.restorePathPrefix }}"

--- a/cockroachdb/cockroachdb-blueprint.yaml
+++ b/cockroachdb/cockroachdb-blueprint.yaml
@@ -151,7 +151,7 @@ actions:
       - func: KubeTask
         name: deleteFromS3Store
         args:
-          image: ghcr.io/kanisterio/kanister-tools:0.116.0
+          image: ghcr.io/kanisterio/kanister-tools:0.118.0
           namespace: "{{ .Namespace.Name }}"
           command:
             - bash

--- a/couchbase/couchbase-blueprint.yaml
+++ b/couchbase/couchbase-blueprint.yaml
@@ -79,7 +79,7 @@ actions:
       name: deleteBackup
       args:
         namespace: "{{ .Namespace.Name }}"
-        image: ghcr.io/kanisterio/kanister-tools:0.116.0
+        image: ghcr.io/kanisterio/kanister-tools:0.118.0
         command:
           - bash
           - -o

--- a/csi-snapshot/README.md
+++ b/csi-snapshot/README.md
@@ -8,7 +8,7 @@ This example demonstrates Kanister's ability to protect an application called Ti
 
 - Helm 3 installed
 - Kubernetes 1.16+ with Beta APIs enabled
-- Kanister controller version 0.116.0 installed in the cluster, let's assume in namespace `kanister`
+- Kanister controller version 0.118.0 installed in the cluster, let's assume in namespace `kanister`
 - Kanctl CLI installed (https://docs.kanister.io/tooling.html#install-the-tools)
 - VolumeSnapshot CRDs, Snapshot Controller & a CSI Driver
 

--- a/elasticsearch/README.md
+++ b/elasticsearch/README.md
@@ -20,7 +20,7 @@ moving on to Elasticsearch 6.0.
 
 * Kubernetes 1.20+
 * PV provisioner support in the underlying infrastructure
-* Kanister controller version 0.116.0 installed in your cluster
+* Kanister controller version 0.118.0 installed in your cluster
 * Kanctl CLI installed (https://docs.kanister.io/tooling.html#install-the-tools)
 
 ## StatefulSets Details
@@ -74,7 +74,7 @@ Add Kanister Helm repository and install Kanister operator
 ```bash
 $ helm repo add kanister https://charts.kanister.io
 $ helm install kanister --namespace kanister --create-namespace \
-  kanister/kanister-operator --set image.tag=0.116.0
+  kanister/kanister-operator --set image.tag=0.118.0
 ```
 
 ### Create Profile

--- a/elasticsearch/elasticsearch-blueprint.yaml
+++ b/elasticsearch/elasticsearch-blueprint.yaml
@@ -18,7 +18,7 @@ actions:
           namespace: "{{ .StatefulSet.Namespace }}"
       args:
         namespace: "{{ .StatefulSet.Namespace }}"
-        image: "ghcr.io/kanisterio/es-sidecar:0.116.0"
+        image: "ghcr.io/kanisterio/es-sidecar:0.118.0"
         command:
         - bash
         - -o
@@ -48,7 +48,7 @@ actions:
           namespace: "{{ .StatefulSet.Namespace }}"
       args:
         namespace: "{{ .StatefulSet.Namespace }}"
-        image: "ghcr.io/kanisterio/es-sidecar:0.116.0"
+        image: "ghcr.io/kanisterio/es-sidecar:0.118.0"
         command:
         - bash
         - -o
@@ -69,7 +69,7 @@ actions:
       name: deleteFromObjectStore
       args:
         namespace: "{{ .Namespace.Name }}"
-        image: "ghcr.io/kanisterio/es-sidecar:0.116.0"
+        image: "ghcr.io/kanisterio/es-sidecar:0.118.0"
         command:
         - bash
         - -o

--- a/etcd-incluster-ocp/etcd-incluster-ocp-blueprint.yaml
+++ b/etcd-incluster-ocp/etcd-incluster-ocp-blueprint.yaml
@@ -12,7 +12,7 @@ actions:
     - func: KubeTask
       name: takeSnapshot
       args:
-        image: ghcr.io/kanisterio/kanister-kubectl-1.18:0.116.0
+        image: ghcr.io/kanisterio/kanister-kubectl-1.18:0.118.0
         command:
           - sh
           - -o
@@ -35,7 +35,7 @@ actions:
     - func: KubeTask
       name: uploadSnapshot
       args:
-        image: ghcr.io/kanisterio/kanister-kubectl-1.18:0.116.0
+        image: ghcr.io/kanisterio/kanister-kubectl-1.18:0.118.0
         command:
           - sh
           - -o
@@ -53,7 +53,7 @@ actions:
     - func: KubeTask
       name: removeSnapshot
       args:
-        image: ghcr.io/kanisterio/kanister-kubectl-1.18:0.116.0
+        image: ghcr.io/kanisterio/kanister-kubectl-1.18:0.118.0
         command:
           - sh
           - -o
@@ -72,7 +72,7 @@ actions:
       name: deleteFromObjectStore
       args:
         namespace: "{{ .Namespace.Name }}"
-        image: "ghcr.io/kanisterio/kanister-tools:0.116.0"
+        image: "ghcr.io/kanisterio/kanister-tools:0.118.0"
         command:
         - bash
         - -o

--- a/foundationdb/README.md
+++ b/foundationdb/README.md
@@ -24,7 +24,7 @@ cluster.
 on you cluster.
 * Kubernetes 1.9+ with Beta APIs enabled.
 * PV support on the underlying infrastructure.
-* Kanister version 0.116.0 with `profiles.cr.kanister.io` CRD installed.
+* Kanister version 0.118.0 with `profiles.cr.kanister.io` CRD installed.
 * Docker CLI installed
 * A docker image containing the required tools to back up FoundationDB.
 The Dockerfile for the image can be found [here](https://raw.githubusercontent.com/kanisterio/kanister/master/docker/foundationdb/Dockerfile).

--- a/foundationdb/blueprint-v2/foundationdb-blueprint.yaml
+++ b/foundationdb/blueprint-v2/foundationdb-blueprint.yaml
@@ -77,7 +77,7 @@ actions:
       name: deleteBackup
       args:
         namespace: "{{ .Namespace.Name }}"
-        image: ghcr.io/kanisterio/kanister-tools:0.116.0
+        image: ghcr.io/kanisterio/kanister-tools:0.118.0
         command:
           - bash
           - -o

--- a/k8ssandra/README.md
+++ b/k8ssandra/README.md
@@ -8,7 +8,7 @@ K8ssandra operator uses Medusa to backup and restore Cassandra data. Kanister ca
 
 * Kubernetes 1.17+
 * PV support on the underlying infrastructure
-* Kanister controller version 0.116.0 installed in your cluster
+* Kanister controller version 0.118.0 installed in your cluster
 * Kanctl CLI installed (https://docs.kanister.io/tooling.html#kanctl)
 * K8ssandra needs at least 4 cores and 8GB of RAM available to Docker and appropriate heap sizes for Cassandra and Stargate. If you don’t have those resources available, you can avoid deploying features such as monitoring, Reaper and Medusa, and also reduce the number of Cassandra nodes.
 

--- a/kafka-adobe-s3-connector/README.md
+++ b/kafka-adobe-s3-connector/README.md
@@ -6,7 +6,7 @@ During restore, topic messages are purged before the restore operation is perfor
 ## Prerequisites
 
 * Kubernetes 1.9+
-* Kanister controller version 0.116.0 installed in the cluster in a namespace <kanister-operator-namespace>. This example uses `kanister` namespace
+* Kanister controller version 0.118.0 installed in the cluster in a namespace <kanister-operator-namespace>. This example uses `kanister` namespace
 * Kanctl CLI installed (https://docs.kanister.io/tooling.html#kanctl)
 
 ## Assumption

--- a/maria/blueprint-v2/maria-blueprint.yaml
+++ b/maria/blueprint-v2/maria-blueprint.yaml
@@ -19,7 +19,7 @@ actions:
           name: '{{ .StatefulSet.Name }}'
           namespace: '{{ .StatefulSet.Namespace }}'
       args:
-        image: ghcr.io/kanisterio/mysql-sidecar:0.116.0
+        image: ghcr.io/kanisterio/mysql-sidecar:0.118.0
         namespace: "{{ .StatefulSet.Namespace }}"
         command:
         - bash
@@ -53,7 +53,7 @@ actions:
           name: '{{ .StatefulSet.Name }}'
           namespace: '{{ .StatefulSet.Namespace }}'
       args:
-        image: ghcr.io/kanisterio/mysql-sidecar:0.116.0
+        image: ghcr.io/kanisterio/mysql-sidecar:0.118.0
         namespace: "{{ .StatefulSet.Namespace }}"
         command:
         - bash
@@ -76,7 +76,7 @@ actions:
     - func: KubeTask
       name: deleteFromStore
       args:
-        image: ghcr.io/kanisterio/mysql-sidecar:0.116.0
+        image: ghcr.io/kanisterio/mysql-sidecar:0.118.0
         namespace: "{{ .Namespace.Name }}"
         command:
         - bash

--- a/maria/maria-blueprint.yaml
+++ b/maria/maria-blueprint.yaml
@@ -17,7 +17,7 @@ actions:
           name: '{{ .StatefulSet.Name }}'
           namespace: '{{ .StatefulSet.Namespace }}'
       args:
-        image: ghcr.io/kanisterio/mysql-sidecar:0.116.0
+        image: ghcr.io/kanisterio/mysql-sidecar:0.118.0
         namespace: "{{ .StatefulSet.Namespace }}"
         command:
         - bash
@@ -49,7 +49,7 @@ actions:
           name: '{{ .StatefulSet.Name }}'
           namespace: '{{ .StatefulSet.Namespace }}'
       args:
-        image: ghcr.io/kanisterio/mysql-sidecar:0.116.0
+        image: ghcr.io/kanisterio/mysql-sidecar:0.118.0
         namespace: "{{ .StatefulSet.Namespace }}"
         command:
         - bash
@@ -69,7 +69,7 @@ actions:
     - func: KubeTask
       name: deleteFromBlobStore
       args:
-        image: ghcr.io/kanisterio/mysql-sidecar:0.116.0
+        image: ghcr.io/kanisterio/mysql-sidecar:0.118.0
         namespace: "{{ .Namespace.Name }}"
         command:
         - bash

--- a/mongo-sidecar/README.md
+++ b/mongo-sidecar/README.md
@@ -7,7 +7,7 @@ This is an example of using Kanister to backup and restore MongoDB. In this exam
 
 - Kubernetes 1.20+
 - PV provisioner support in the underlying infrastructure
-- Kanister controller version 0.116.0 installed in your cluster, let's assume in Namespace `kanister`
+- Kanister controller version 0.118.0 installed in your cluster, let's assume in Namespace `kanister`
 - Kanctl CLI installed (https://docs.kanister.io/tooling.html#install-the-tools)
 
 

--- a/mongodb-atlas/README.md
+++ b/mongodb-atlas/README.md
@@ -7,7 +7,7 @@ It deploys and scales a MongoDB cluster in the cloud.
 ## Prerequisites
 
 * Kubernetes 1.20+
-* Kanister controller version 0.116.0 installed in your cluster
+* Kanister controller version 0.118.0 installed in your cluster
 * Kanctl CLI installed (https://docs.kanister.io/tooling.html#install-the-tools)
 * Already provisioned MongoDB Atlas cluster (https://www.mongodb.com/docs/atlas/getting-started)
 
@@ -19,7 +19,7 @@ to install.
 ```bash
 $ helm repo add kanister https://charts.kanister.io
 $ helm install kanister --namespace kanister --create-namespace \
-    kanister/kanister-operator --set image.tag=0.116.0
+    kanister/kanister-operator --set image.tag=0.118.0
 ```
 
 ### Create Blueprint

--- a/mongodb-dep-config/README.md
+++ b/mongodb-dep-config/README.md
@@ -14,7 +14,7 @@ cluster's DeploymentConfig resources.
 
 - Setup OpenShift, you can follow steps mentioned below
 - PV provisioner support in the underlying infrastructure
-- Kanister controller version 0.116.0 installed in your cluster in namespace `kanister`
+- Kanister controller version 0.118.0 installed in your cluster in namespace `kanister`
 - Kanctl CLI installed (https://docs.kanister.io/tooling.html#kanctl)
 
 **Note**

--- a/mongodb-dep-config/mongodb-dep-config-blueprint.yaml
+++ b/mongodb-dep-config/mongodb-dep-config-blueprint.yaml
@@ -18,7 +18,7 @@ actions:
           namespace: "{{ .DeploymentConfig.Namespace }}"
       args:
         namespace: "{{ .DeploymentConfig.Namespace }}"
-        image: ghcr.io/kanisterio/mongodb:0.116.0
+        image: ghcr.io/kanisterio/mongodb:0.118.0
         command:
           - bash
           - -o
@@ -45,7 +45,7 @@ actions:
           namespace: "{{ .DeploymentConfig.Namespace }}"
       args:
         namespace: "{{ .DeploymentConfig.Namespace }}"
-        image: ghcr.io/kanisterio/mongodb:0.116.0
+        image: ghcr.io/kanisterio/mongodb:0.118.0
         command:
           - bash
           - -o
@@ -66,7 +66,7 @@ actions:
       name: deleteFromBlobStore
       args:
         namespace: "{{ .Namespace.Name }}"
-        image: ghcr.io/kanisterio/mongodb:0.116.0
+        image: ghcr.io/kanisterio/mongodb:0.118.0
         command:
           - bash
           - -o

--- a/mongodb-restic/README.md
+++ b/mongodb-restic/README.md
@@ -7,7 +7,7 @@
 * Kubernetes 1.9+
 * Kubernetes beta APIs enabled only if `podDisruptionBudget` is enabled
 * PV support on the underlying infrastructure
-* Kanister controller version 0.116.0 installed in your cluster
+* Kanister controller version 0.118.0 installed in your cluster
 * Kanctl CLI installed (https://docs.kanister.io/tooling.html#kanctl)
 
 ## Chart Details
@@ -28,7 +28,7 @@ $ kubectl create namespace mongo-test
 $ helm install my-release bitnami/mongodb --namespace mongo-test \
 	--set architecture="replicaset" \
 	--set image.repository=ghcr.io/kanisterio/mongodb \
-	--set image.tag=0.116.0
+	--set image.tag=0.118.0
 ```
 
 The command deploys MongoDB on the Kubernetes cluster in the mongo-test namespace

--- a/mongodb-restic/mongodb-restic-blueprint.yaml
+++ b/mongodb-restic/mongodb-restic-blueprint.yaml
@@ -39,7 +39,7 @@ actions:
       name: restorePrimary
       args:
         namespace: "{{ .StatefulSet.Namespace }}"
-        image: ghcr.io/kanisterio/kanister-tools:0.116.0
+        image: ghcr.io/kanisterio/kanister-tools:0.118.0
         backupArtifactPrefix: "{{ .Profile.Location.Bucket }}/mongodb-backups/{{ .StatefulSet.Name }}/rs_backup"
         backupInfo: "{{ .ArtifactsIn.backupInfo.KeyValue.backupIdentifier }}"
 

--- a/mongodb/README.md
+++ b/mongodb/README.md
@@ -7,7 +7,7 @@
 * Kubernetes 1.20+
 * Kubernetes beta APIs enabled only if `podDisruptionBudget` is enabled
 * PV support on the underlying infrastructure
-* Kanister controller version 0.116.0 installed in your cluster
+* Kanister controller version 0.118.0 installed in your cluster
 * Kanctl CLI installed (https://docs.kanister.io/tooling.html#install-the-tools)
 
 ## Chart Details

--- a/mongodb/mongodb-blueprint.yaml
+++ b/mongodb/mongodb-blueprint.yaml
@@ -18,7 +18,7 @@ actions:
           namespace: "{{ .StatefulSet.Namespace }}"
       args:
         namespace: "{{ .StatefulSet.Namespace }}"
-        image: ghcr.io/kanisterio/mongodb:0.116.0
+        image: ghcr.io/kanisterio/mongodb:0.118.0
         command:
           - bash
           - -o
@@ -44,7 +44,7 @@ actions:
           namespace: "{{ .StatefulSet.Namespace }}"
       args:
         namespace: "{{ .StatefulSet.Namespace }}"
-        image: ghcr.io/kanisterio/mongodb:0.116.0
+        image: ghcr.io/kanisterio/mongodb:0.118.0
         command:
           - bash
           - -o
@@ -65,7 +65,7 @@ actions:
       name: deleteFromBlobStore
       args:
         namespace: "{{ .Namespace.Name }}"
-        image: ghcr.io/kanisterio/mongodb:0.116.0
+        image: ghcr.io/kanisterio/mongodb:0.118.0
         command:
           - bash
           - -o

--- a/mssql/README.md
+++ b/mssql/README.md
@@ -9,7 +9,7 @@ This document will cover how to install SQL Server and how to run backup/restore
 
 - Kubernetes 1.16+ with Beta APIs enabled
 - PV provisioner support in the underlying infrastructure
-- Kanister controller version 0.116.0 installed in your cluster, let's assume in Namespace `kanister`
+- Kanister controller version 0.118.0 installed in your cluster, let's assume in Namespace `kanister`
 - Kanctl CLI installed (https://docs.kanister.io/tooling.html#install-the-tools)
 
 ## Installing Microsoft SQL Server

--- a/mssql/mssql-blueprint.yaml
+++ b/mssql/mssql-blueprint.yaml
@@ -14,7 +14,7 @@ actions:
       - func: KubeTask
         name: dumpToObjectStore
         args:
-          image: ghcr.io/kanisterio/mssql-tools:0.116.0
+          image: ghcr.io/kanisterio/mssql-tools:0.118.0
           command:
             - bash
             - -o
@@ -45,7 +45,7 @@ actions:
       - func: KubeTask
         name: restoreFromObjectStore
         args:
-          image: ghcr.io/kanisterio/mssql-tools:0.116.0
+          image: ghcr.io/kanisterio/mssql-tools:0.118.0
           command:
             - bash
             - -o
@@ -71,7 +71,7 @@ actions:
       - func: KubeTask
         name: deleteFromBlobStore
         args:
-          image: ghcr.io/kanisterio/mssql-tools:0.116.0
+          image: ghcr.io/kanisterio/mssql-tools:0.118.0
           command:
             - bash
             - -o

--- a/mysql-dep-config/README.md
+++ b/mysql-dep-config/README.md
@@ -14,7 +14,7 @@ cluster's DeploymentConfig resources.
 
 - Setup OpenShift, you can follow steps mentioned below
 - PV provisioner support in the underlying infrastructure
-- Kanister controller version 0.116.0 installed in your cluster in namespace `kanister`
+- Kanister controller version 0.118.0 installed in your cluster in namespace `kanister`
 - Kanctl CLI installed (https://docs.kanister.io/tooling.html#kanctl)
 
 **Note**

--- a/mysql-dep-config/mysql-dep-config-blueprint.yaml
+++ b/mysql-dep-config/mysql-dep-config-blueprint.yaml
@@ -17,7 +17,7 @@ actions:
           name: "{{ .DeploymentConfig.Name }}"
           namespace: "{{ .DeploymentConfig.Namespace }}"
       args:
-        image: ghcr.io/kanisterio/mysql-sidecar:0.116.0
+        image: ghcr.io/kanisterio/mysql-sidecar:0.118.0
         namespace: "{{ .DeploymentConfig.Namespace }}"
         command:
         - bash
@@ -43,7 +43,7 @@ actions:
           name: "{{ .DeploymentConfig.Name }}"
           namespace: "{{ .DeploymentConfig.Namespace }}"
       args:
-        image: ghcr.io/kanisterio/mysql-sidecar:0.116.0
+        image: ghcr.io/kanisterio/mysql-sidecar:0.118.0
         namespace: "{{ .DeploymentConfig.Namespace }}"
         command:
         - bash
@@ -63,7 +63,7 @@ actions:
     - func: KubeTask
       name: deleteFromBlobStore
       args:
-        image: ghcr.io/kanisterio/mysql-sidecar:0.116.0
+        image: ghcr.io/kanisterio/mysql-sidecar:0.118.0
         namespace: "{{ .Namespace.Name }}"
         command:
         - bash

--- a/mysql/README.md
+++ b/mysql/README.md
@@ -10,7 +10,7 @@ This chart bootstraps a single node MySQL deployment on a [Kubernetes](http://ku
 
 - Kubernetes 1.20+
 - PV provisioner support in the underlying infrastructure
-- Kanister controller version 0.116.0 installed in your cluster, let's assume in Namespace `kanister`
+- Kanister controller version 0.118.0 installed in your cluster, let's assume in Namespace `kanister`
 - Kanctl CLI installed (https://docs.kanister.io/tooling.html#install-the-tools)
 
 ## Installing the Chart

--- a/mysql/mysql-blueprint.yaml
+++ b/mysql/mysql-blueprint.yaml
@@ -17,7 +17,7 @@ actions:
           name: '{{ index .Object.metadata.labels "app.kubernetes.io/instance" }}'
           namespace: '{{ .StatefulSet.Namespace }}'
       args:
-        image: ghcr.io/kanisterio/mysql-sidecar:0.116.0
+        image: ghcr.io/kanisterio/mysql-sidecar:0.118.0
         namespace: "{{ .StatefulSet.Namespace }}"
         command:
         - bash
@@ -43,7 +43,7 @@ actions:
           name: '{{ index .Object.metadata.labels "app.kubernetes.io/instance" }}'
           namespace: '{{ .StatefulSet.Namespace }}'
       args:
-        image: ghcr.io/kanisterio/mysql-sidecar:0.116.0
+        image: ghcr.io/kanisterio/mysql-sidecar:0.118.0
         namespace: "{{ .StatefulSet.Namespace }}"
         command:
         - bash
@@ -63,7 +63,7 @@ actions:
     - func: KubeTask
       name: deleteFromBlobStore
       args:
-        image: ghcr.io/kanisterio/mysql-sidecar:0.116.0
+        image: ghcr.io/kanisterio/mysql-sidecar:0.118.0
         namespace: "{{ .Namespace.Name }}"
         command:
         - bash

--- a/postgres-dep-config/README.md
+++ b/postgres-dep-config/README.md
@@ -14,7 +14,7 @@ cluster's DeploymentConfig resources.
 
 - Setup OpenShift, you can follow steps mentioned below
 - PV provisioner support in the underlying infrastructure
-- Kanister controller version 0.116.0 installed in your cluster in namespace `kanister`
+- Kanister controller version 0.118.0 installed in your cluster in namespace `kanister`
 - Kanctl CLI installed (https://docs.kanister.io/tooling.html#kanctl)
 
 

--- a/postgres-dep-config/postgres-dep-config-blueprint.yaml
+++ b/postgres-dep-config/postgres-dep-config-blueprint.yaml
@@ -18,7 +18,7 @@ actions:
           name: '{{ .DeploymentConfig.Name }}-{{ .DeploymentConfig.Namespace }}'
           namespace: '{{ .DeploymentConfig.Namespace }}'
       args:
-        image: ghcr.io/kanisterio/postgres-kanister-tools:0.116.0
+        image: ghcr.io/kanisterio/postgres-kanister-tools:0.118.0
         namespace: '{{ .DeploymentConfig.Namespace }}'
         command:
         - bash
@@ -47,7 +47,7 @@ actions:
           name: '{{ .DeploymentConfig.Name }}-{{ .DeploymentConfig.Namespace }}'
           namespace: '{{ .DeploymentConfig.Namespace }}'
       args:
-        image: ghcr.io/kanisterio/postgres-kanister-tools:0.116.0
+        image: ghcr.io/kanisterio/postgres-kanister-tools:0.118.0
         namespace: '{{ .DeploymentConfig.Namespace }}'
         command:
         - bash
@@ -69,7 +69,7 @@ actions:
     - func: KubeTask
       name: deleteDump
       args:
-        image: ghcr.io/kanisterio/postgres-kanister-tools:0.116.0
+        image: ghcr.io/kanisterio/postgres-kanister-tools:0.118.0
         namespace: "{{ .Namespace.Name }}"
         command:
           - bash

--- a/postgres-ha-hook/README.md
+++ b/postgres-ha-hook/README.md
@@ -20,7 +20,7 @@ This blueprint is only required when you face above mentioned issue, else you wi
 
 - Kubernetes 1.10+
 - PV provisioner support in the underlying infrastructure
-- Kanister controller version 0.116.0 installed in your cluster
+- Kanister controller version 0.118.0 installed in your cluster
 - Kanctl CLI installed (https://docs.kanister.io/tooling.html#kanctl)
 
 ## Installing the Chart

--- a/postgres/README.md
+++ b/postgres/README.md
@@ -12,7 +12,7 @@ Bitnami charts can be used with [Kubeapps](https://kubeapps.com/) for deployment
 
 - Kubernetes 1.20+
 - PV provisioner support in the underlying infrastructure
-- Kanister controller version 0.116.0 installed in your cluster
+- Kanister controller version 0.118.0 installed in your cluster
 - Kanctl CLI installed (https://docs.kanister.io/tooling.html#install-the-tools)
 
 ## Installing the Chart
@@ -37,7 +37,7 @@ In case, if you don't have `Kanister` installed already, you can use following c
 Add Kanister Helm repository and install Kanister operator
 ```bash
 $ helm repo add kanister https://charts.kanister.io
-$ helm install kanister --namespace kanister --create-namespace kanister/kanister-operator --set image.tag=0.116.0
+$ helm install kanister --namespace kanister --create-namespace kanister/kanister-operator --set image.tag=0.118.0
 ```
 
 ## Integrating with Kanister

--- a/postgres/postgres-blueprint.yaml
+++ b/postgres/postgres-blueprint.yaml
@@ -18,7 +18,7 @@ actions:
           name: '{{ index .Object.metadata.labels "app.kubernetes.io/instance" }}-postgresql'
           namespace: '{{ .StatefulSet.Namespace }}'
       args:
-        image: ghcr.io/kanisterio/postgres-kanister-tools:0.116.0
+        image: ghcr.io/kanisterio/postgres-kanister-tools:0.118.0
         namespace: '{{ .StatefulSet.Namespace }}'
         command:
         - bash
@@ -47,7 +47,7 @@ actions:
           name: '{{ index .Object.metadata.labels "app.kubernetes.io/instance" }}-postgresql'
           namespace: '{{ .StatefulSet.Namespace }}'
       args:
-        image: ghcr.io/kanisterio/postgres-kanister-tools:0.116.0
+        image: ghcr.io/kanisterio/postgres-kanister-tools:0.118.0
         namespace: '{{ .StatefulSet.Namespace }}'
         command:
         - bash
@@ -69,7 +69,7 @@ actions:
     - func: KubeTask
       name: deleteDump
       args:
-        image: ghcr.io/kanisterio/postgres-kanister-tools:0.116.0
+        image: ghcr.io/kanisterio/postgres-kanister-tools:0.118.0
         namespace: "{{ .Namespace.Name }}"
         command:
           - bash

--- a/postgres/v10.16.2/postgres-blueprint.yaml
+++ b/postgres/v10.16.2/postgres-blueprint.yaml
@@ -18,7 +18,7 @@ actions:
           name: '{{ index .Object.metadata.labels "app.kubernetes.io/instance" }}-postgresql'
           namespace: '{{ .StatefulSet.Namespace }}'
       args:
-        image: ghcr.io/kanisterio/postgres-kanister-tools:0.116.0
+        image: ghcr.io/kanisterio/postgres-kanister-tools:0.118.0
         namespace: '{{ .StatefulSet.Namespace }}'
         command:
         - bash
@@ -47,7 +47,7 @@ actions:
           name: '{{ index .Object.metadata.labels "app.kubernetes.io/instance" }}-postgresql'
           namespace: '{{ .StatefulSet.Namespace }}'
       args:
-        image: ghcr.io/kanisterio/postgres-kanister-tools:0.116.0
+        image: ghcr.io/kanisterio/postgres-kanister-tools:0.118.0
         namespace: '{{ .StatefulSet.Namespace }}'
         command:
         - bash
@@ -69,7 +69,7 @@ actions:
     - func: KubeTask
       name: deleteDump
       args:
-        image: ghcr.io/kanisterio/postgres-kanister-tools:0.116.0
+        image: ghcr.io/kanisterio/postgres-kanister-tools:0.118.0
         namespace: "{{ .Namespace.Name }}"
         command:
           - bash

--- a/postgresql-wale/README.md
+++ b/postgresql-wale/README.md
@@ -12,7 +12,7 @@ Bitnami charts can be used with [Kubeapps](https://kubeapps.com/) for deployment
 
 - Kubernetes 1.10+
 - PV provisioner support in the underlying infrastructure
-- Kanister controller version 0.116.0 installed in your cluster
+- Kanister controller version 0.118.0 installed in your cluster
 - Kanctl CLI installed (https://docs.kanister.io/tooling.html#kanctl)
 
 ## Installing the Chart
@@ -25,7 +25,7 @@ $ helm repo update
 $ helm install my-release bitnami/postgresql  \
 	--namespace postgres-test --create-namespace \
 	--set image.repository=ghcr.io/kanisterio/postgresql \
-	--set image.tag=0.116.0 \
+	--set image.tag=0.118.0 \
 	--set postgresqlPassword=postgres-12345 \
 	--set postgresqlExtendedConf.archiveCommand="'envdir /bitnami/postgresql/data/env wal-e wal-push %p'" \
 	--set postgresqlExtendedConf.archiveMode=true \
@@ -41,7 +41,7 @@ In case, if you don't have `Kanister` installed already, you can use following c
 Add Kanister Helm repository and install Kanister operator
 ```bash
 $ helm repo add kanister https://charts.kanister.io
-$ helm install kanister --namespace kanister --create-namespace kanister/kanister-operator --set image.tag=0.116.0
+$ helm install kanister --namespace kanister --create-namespace kanister/kanister-operator --set image.tag=0.118.0
 ```
 
 ## Integrating with Kanister

--- a/postgresql-wale/postgresql-wale-blueprint.yaml
+++ b/postgresql-wale/postgresql-wale-blueprint.yaml
@@ -132,7 +132,7 @@ actions:
     - func: PrepareData
       name: performRestore
       args:
-        image: "ghcr.io/kanisterio/postgresql:0.116.0"
+        image: "ghcr.io/kanisterio/postgresql:0.118.0"
         namespace: "{{ .StatefulSet.Namespace }}"
         volumes:
           "data-{{ .StatefulSet.Name }}-0": "/bitnami/postgresql"
@@ -282,7 +282,7 @@ actions:
       name: deleteArtifact
       args:
         namespace: "{{ .Namespace.Name }}"
-        image: "ghcr.io/kanisterio/postgresql:0.116.0"
+        image: "ghcr.io/kanisterio/postgresql:0.118.0"
         command:
           - bash
           - -o

--- a/redis/README.md
+++ b/redis/README.md
@@ -11,7 +11,7 @@ We will be using [Redis](https://github.com/bitnami/charts/tree/main/bitnami/red
 
 - Kubernetes 1.20+
 - PV provisioner support in the underlying infrastructure
-- Kanister controller version 0.116.0 installed in your cluster, let's assume in Namespace `kanister`
+- Kanister controller version 0.118.0 installed in your cluster, let's assume in Namespace `kanister`
 - Kanctl CLI installed (https://docs.kanister.io/tooling.html#install-the-tools)
 - Docker CLI installed
 - A docker image containing the required tools to back up Redis. The Dockerfile for the image can be found [here](https://raw.githubusercontent.com/kanisterio/kanister/master/docker/redis-tools/Dockerfile). To build and push the docker image to your docker registry, execute [these](#build-docker-image) steps.

--- a/time-log/time-log-blueprint.yaml
+++ b/time-log/time-log-blueprint.yaml
@@ -38,7 +38,7 @@ actions:
       args:
         namespace: "{{ .Deployment.Namespace }}"
         pod: "{{ index .Deployment.Pods 0 }}"
-        image: ghcr.io/kanisterio/kanister-tools:0.116.0
+        image: ghcr.io/kanisterio/kanister-tools:0.118.0
         backupArtifactPrefix: "{{ .ArtifactsIn.timeLog.KeyValue.path }}"
         backupIdentifier: "{{ .ArtifactsIn.backupIdentifier.KeyValue.id }}"
     - func: ScaleWorkload

--- a/time-log/time-logger-deployment.yaml
+++ b/time-log/time-logger-deployment.yaml
@@ -27,7 +27,7 @@ spec:
     spec:
       containers:
       - name: test-container
-        image: ghcr.io/kanisterio/kanister-tools:0.116.0
+        image: ghcr.io/kanisterio/kanister-tools:0.118.0
         command: ["sh", "-c"]
         args: ["while true; do for x in $(seq 1200); do date >> /var/log/time.log; sleep 1; done; truncate /var/log/time.log --size 0; done"]
         volumeMounts:


### PR DESCRIPTION
## Change Overview

This PR upgrades the Kanister blueprint version to v0.118.0.

After splitting the Kanister blueprints into a separate repository, the pre-release workflow stopped automatically updating to newer versions. Although a fix was introduced, it is currently ineffective because the blueprint repository is still on v0.116.0.

This change manually updates the blueprint version to v0.118.0 so it aligns with the current Kanister release and restores the expected pre-release workflow behavior.

## Pull request type

Please check the type of change your PR introduces:
- [ ] :construction: Work in Progress
- [x] :hamster: Trivial/Minor
- [ ] :sunflower: Feature
- [ ] :world_map: Documentation
